### PR TITLE
Patch 1

### DIFF
--- a/RAReorderableLayout/RAReorderableLayout.swift
+++ b/RAReorderableLayout/RAReorderableLayout.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @objc public protocol RAReorderableLayoutDelegate: UICollectionViewDelegateFlowLayout {
-        optional func collectionView(collectionView: UIColleoctionView, atIndexPath: NSIndexPath, willMoveToIndexPath toIndexPath: NSIndexPath)
+        optional func collectionView(collectionView: UICollectionView, atIndexPath: NSIndexPath, willMoveToIndexPath toIndexPath: NSIndexPath)
         optional func collectionView(collectionView: UICollectionView, atIndexPath: NSIndexPath, didMoveToIndexPath toIndexPath: NSIndexPath)
         
         optional func collectionView(collectionView: UICollectionView, allowMoveAtIndexPath indexPath: NSIndexPath) -> Bool

--- a/RAReorderableLayout/RAReorderableLayout.swift
+++ b/RAReorderableLayout/RAReorderableLayout.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @objc public protocol RAReorderableLayoutDelegate: UICollectionViewDelegateFlowLayout {
-        optional func collectionView(collectionView: UICollectionView, atIndexPath: NSIndexPath, willMoveToIndexPath toIndexPath: NSIndexPath)
+        optional func collectionView(collectionView: UIColleoctionView, atIndexPath: NSIndexPath, willMoveToIndexPath toIndexPath: NSIndexPath)
         optional func collectionView(collectionView: UICollectionView, atIndexPath: NSIndexPath, didMoveToIndexPath toIndexPath: NSIndexPath)
         
         optional func collectionView(collectionView: UICollectionView, allowMoveAtIndexPath indexPath: NSIndexPath) -> Bool
@@ -160,7 +160,7 @@ public class RAReorderableLayout: UICollectionViewFlowLayout, UIGestureRecognize
                 self.configureObserver()
         }
         
-        override init() {
+        public override init() {
                 super.init()
                 self.configureObserver()
         }


### PR DESCRIPTION
Marked `init()` as public, so it can be exposed in outside frameworks (like if you're using this in CocoaPods or Carthage).