### PR TITLE
fixed HorizontalViewController::collectionView.bounds.

### DIFF
--- a/RAReorderableLayout-Demo/RAReorderableLayout-Demo/HorizontalViewController.swift
+++ b/RAReorderableLayout-Demo/RAReorderableLayout-Demo/HorizontalViewController.swift
@@ -41,7 +41,6 @@ class HorizontalViewController: UIViewController, RAReorderableLayoutDelegate, R
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        collectionView.contentInset = UIEdgeInsetsMake(topLayoutGuide.length, 0, 0, 0)
         gradientLayer?.frame = gradientView.bounds
     }
     


### PR DESCRIPTION
The collection view's bounds, which is in HorizontalViewController of the sample project, does not fit its frame. 
- before:(0.0, -64.0, 414.0, 300.0)
- after :(0.0,   0.0, 414.0, 300.0)