### PR TITLE
Gesture recongizers only set up once

### DIFF
--- a/RAReorderableLayout/RAReorderableLayout.swift
+++ b/RAReorderableLayout/RAReorderableLayout.swift
@@ -322,6 +322,7 @@ public class RAReorderableLayout: UICollectionViewFlowLayout, UIGestureRecognize
     // gesture recognizers
     private func setUpGestureRecognizers() {
         guard let collectionView = collectionView else { return }
+        guard longPress == nil && panGesture == nil else {return }
         
         longPress = UILongPressGestureRecognizer(target: self, action: #selector(RAReorderableLayout.handleLongPress(_:)))
         panGesture = UIPanGestureRecognizer(target: self, action: #selector(RAReorderableLayout.handlePanGesture(_:)))


### PR DESCRIPTION
Had some issues with gesture recognizers being set up multiple times. Thus, cancelDrag was called twice, which crashed the app the second time since cellFakeView is force unwrapped. Proposed this simple fix