### PR TITLE
change the access level for delegate and dataSource

### DIFF
--- a/RAReorderableLayout/RAReorderableLayout.swift
+++ b/RAReorderableLayout/RAReorderableLayout.swift
@@ -84,12 +84,12 @@ open class RAReorderableLayout: UICollectionViewFlowLayout, UIGestureRecognizerD
         }
     }
     
-     weak var delegate: RAReorderableLayoutDelegate? {
+     public weak var delegate: RAReorderableLayoutDelegate? {
         get { return collectionView?.delegate as? RAReorderableLayoutDelegate }
         set { collectionView?.delegate = delegate }
     }
     
-     weak var dataSource: RAReorderableLayoutDataSource? {
+     public weak var dataSource: RAReorderableLayoutDataSource? {
         set { collectionView?.dataSource = dataSource }
         get { return collectionView?.dataSource as? RAReorderableLayoutDataSource }
     }


### PR DESCRIPTION
Should change the default `internal` level to `public` level to allow outside access in Swift 3. 
