### PR TITLE
Fixed incorrect removing IndexPath in example

### DIFF
--- a/RAReorderableLayout-Demo/RAReorderableLayout-Demo/HorizontalViewController.swift
+++ b/RAReorderableLayout-Demo/RAReorderableLayout-Demo/HorizontalViewController.swift
@@ -88,7 +88,7 @@ class HorizontalViewController: UIViewController, RAReorderableLayoutDelegate, R
     }
     
     func collectionView(_ collectionView: UICollectionView, at: IndexPath, didMoveTo toIndexPath: IndexPath) {
-        let book = books.remove(at: (toIndexPath as NSIndexPath).item)
+        let book = books.remove(at: (at as NSIndexPath).item)
         books.insert(book, at: (toIndexPath as NSIndexPath).item)
     }
     


### PR DESCRIPTION
In HorizontalViewController in moving data logic always uses toIndexPath. But correct way is remove book from "at" IndexPath and insert "to" IndexPath.